### PR TITLE
Reduce dependencies to a minimum

### DIFF
--- a/dkml-c-probe.opam
+++ b/dkml-c-probe.opam
@@ -13,7 +13,6 @@ bug-reports: "https://github.com/diskuv/dkml-c-probe/issues"
 depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.12.1"}
-  "astring" {>= "0.8.5"}
   "mdx" {>= "2.0.0" & with-test}
   "dune-configurator" {>= "2.9" & build}
   "odoc" {with-doc}

--- a/dune
+++ b/dune
@@ -3,18 +3,23 @@
 (rule
  (deps src/config/dkml_compiler_probe.h)
  (target dkml_compiler_probe.h)
- (action (copy %{deps} %{target})))
+ (action
+  (copy %{deps} %{target})))
 
 ; Diagnostics. Use (universe) to always display it.
+
 (rule
  (alias runtest)
- (deps (package dkml-c-probe) (universe))
+ (deps
+  (package dkml-c-probe)
+  (universe))
  (action
-   (with-stdin-from
-     show_abi.ml
-     (run ocaml))))
+  (with-stdin-from
+   show_abi.ml
+   (run ocaml))))
 
 ; BEGIN HACK - Workaround unsupported ```console blocks
+
 (rule
  (deps README.md)
  (target README.md.sh)
@@ -22,11 +27,17 @@
   (with-stdout-to
    %{target}
    (run sed "s/```console/```sh/g" %{deps}))))
+
 (rule
- (deps (:in README.md.sh) src/dkml_c_probe.cma show_signature.ml dkml_compiler_probe.h)
+ (deps
+  (:in README.md.sh)
+  src/dkml_c_probe.cma
+  show_signature.ml
+  dkml_compiler_probe.h)
  (target README.md.sh.corrected)
  (action
   (run ocaml-mdx test --force-output %{in})))
+
 (rule
  (deps README.md.sh.corrected)
  (target README.md.corrected)
@@ -34,9 +45,11 @@
   (with-stdout-to
    %{target}
    (run sed "s/```sh/```console/g" %{deps}))))
+
 (rule
  (alias runmarkdown)
  (action
   (progn
    (diff README.md README.md.corrected))))
+
 ; END HACK

--- a/dune-project
+++ b/dune-project
@@ -20,6 +20,5 @@
  (description "Using the C compiler of ocamlopt -config, which may be a cross-compiler, vends an OCaml module with enumerations of the target operating system and ABI, and a C header that introspects the same at compile time")
  (depends
   (ocaml    (>= 4.12.1))
-  (astring  (>= 0.8.5))
   (mdx      (and (>= 2.0.0) :with-test))
   (dune-configurator (and (>= 2.9) :build))))

--- a/src/config/dune
+++ b/src/config/dune
@@ -3,7 +3,7 @@
  (modules create_ocaml_from_file)
  ; No PPX! Since this is core to DKML this should compile with the bare minimum
  ; Diskuv OCaml dependencies from the `dkml` switch
- (libraries astring))
+ )
 
 (rule
  (target dkml_compiler_probe_c_header.ml)


### PR DESCRIPTION
The `dune` file was modified by `dune build @fmt`, I am happy to revert the format changes if you prefer.
I think `dos2unix` should be equivalent to what you had. I think also `Astring.String.Ascii.escape_string` should be equivalent to `String.escaped`, but I am not 100% sure. All the function used predate ocaml 4.12 afaik

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>